### PR TITLE
Upgraded vscode dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "testls-client",
-    "displayName": "testls_client",
+    "name": "rls_vscode",
+    "displayName": "rls_vscode",
     "description": "",
     "version": "0.0.1",
     "publisher": "JonathanTurner",
     "engines": {
-        "vscode": "^1.4.0"
+        "vscode": "^1.7.0"
     },
     "categories": [
         "Languages",
         "Linters",
         "Other"
     ],
-	"activationEvents": [
-		"onLanguage:rust"
+    "activationEvents": [
+        "onLanguage:rust"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -23,16 +23,17 @@
         }]
     },
     "scripts": {
-        "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-        "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+        "vscode:prepublish": "tsc -p ./",
+        "compile": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "dependencies": {
-        "vscode-languageclient": "^2.2.1",
-        "vscode-languageserver": "^2.2.0"
+        "vscode-languageclient": "^2.6.3",
+        "vscode-languageserver": "^2.6.2"
     },
     "devDependencies": {
-        "typescript": "^1.8.5",
-        "vscode": "^0.11.0"
+        "typescript": "^2.0.3",
+        "vscode": "^1.0.3",
+        "@types/node": "^6.0.40"
     }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "devDependencies": {
         "typescript": "^2.0.3",
         "vscode": "^1.0.3",
+        "mocha": "^2.3.3",
+        "@types/mocha": "^2.2.32",
         "@types/node": "^6.0.40"
     }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "0.0.1",
     "publisher": "JonathanTurner",
     "engines": {
-        "vscode": "^1.7.0"
+        "vscode": "^1.8.0"
     },
     "categories": [
         "Languages",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "outDir": "out",
-        "noLib": true,
+        "lib": ["es6"],
         "sourceMap": true,
         "rootDir": "."
     },

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/typings/vscode-typings.d.ts
+++ b/typings/vscode-typings.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/index.d.ts" />


### PR DESCRIPTION
I did this while debugging an issue I was having; unfortunately it didn't help, but at least it shouldn't make things worse (and moving onto later versions is usually a good thing).

This should be tested by someone else than me; I get errors like below both before and after this change, so it's hard for me to verify that it's fully working. But at least it builds.

```
Uncaught Exception:  Error: Header must provide a Content-Length property.
Error: Header must provide a Content-Length property.
    at StreamMessageReader.onData (/Users/per/git/rls_vscode/node_modules/vscode-jsonrpc/lib/messageReader.js:179:27)
    at Socket.<anonymous> (/Users/per/git/rls_vscode/node_modules/vscode-jsonrpc/lib/messageReader.js:164:19)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at Socket.Readable.push (_stream_readable.js:134:10)
    at Pipe.onread (net.js:543:20)
```