### PR TITLE
Add manual VSCode extension installation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,16 @@ variable to the root of your rls checkout:
 ```
 export RLS_ROOT=/Source/rls
 ```  
+You can also add this export to your bash profile or equivalent.
+
+## Manually add as regular VSCode extension
+
+If you'd like to test on multiple projects and already have the extension working properly, you can manually install the extension so that it's loaded into VSCode by default.
+
+After following the above instructions, and successfully building the extension once, symlink or copy the `rls_vscode` directory to either:
+```
+Windows: %USERPROFILE%\.vscode\extensions
+Mac/Linux: $HOME/.vscode/extensions
+```
+For example, to setup a symlink on Mac/Linux: `ln -s /path/to/rls_vscode/ ~/.vscode/extensions/rls_vscode`
+Restart VSCode in order to load the extension. More information available via [VSCode docs](https://code.visualstudio.com/Docs/extensions/example-hello-world#_installing-your-extension-locally).


### PR DESCRIPTION
Thanks for the fantastic work, just wanted to add a few notes on how to manually install the extension to try on multiple Rust projects without using the debugger. Also added a link to the VSCode extension docs. Hopefully this can save someone else a few minutes of time.

Thanks again, this is an extremely exciting first look at where the rust tooling is headed!