### PR TITLE
Expose trace verbosity

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,8 +6,10 @@ import * as child_process from 'child_process';
 
 import { workspace, Disposable, ExtensionContext, languages, window } from 'vscode';
 import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind } from 'vscode-languageclient';
+import { Trace } from 'vscode-jsonrpc';
 
 let DEV_MODE = false;
+let CLIENT_TRACE = Trace.Messages;
 
 let spinnerTimer = null;
 let spinner = ['|', '/', '-', '\\'];
@@ -76,6 +78,9 @@ export function activate(context: ExtensionContext) {
 
     // Create the language client and start the client.
     let lc = new LanguageClient('Rust Language Server', serverOptions, clientOptions);
+    // Set appropriate client trace verbosity level in dev mode.
+    // Trace.Verbose provides full protocol messages in the client output channel.
+    lc.trace = DEV_MODE ? CLIENT_TRACE : Trace.Off;
 
     let runningDiagnostics = new Counter();
     lc.onNotification({method: "rustDocument/diagnosticsBegin"}, function(f) {


### PR DESCRIPTION
This is another take on https://github.com/jonathandturner/rls_vscode/pull/39 (Add output channel). Currently, from what I looked, there's no way to easily capture protocol messages for debugging/overview purposes, even when running under `DEV_MODE`. So the PR is split into two commits.
Firstly, it allows to trace only protocol messages (either information for sent/received messages or also including the formatted contents) by setting appropriate trace verbosity property in LanguageClient (using built-in API) when ran with `DEV_MODE` set to` true`. I set it to Trace.Messages by default (info about the messages, but not including contents), because it made sense for me to display simple trace logs when run under `DEV_MODE`, but we could make it completely opt-in.
Secondly, it also allows to set RUST_LOG env var when running the server. Not sure if the implementation is good enough, but since the fact that you can provide RUST_LOG to the server is rarely brought up, I just wanted have it there, so people can only toy with setting the desired verbosity when they're hacking on RLS :smile: It's completely opt-in.
If we don't want these two things then maybe we can just introduce one or the other - I didn't want to submit 2 PRs for related things.