### PR TITLE
Nicer error message if rls process could not be spawned

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,17 @@ export function activate(context: ExtensionContext) {
                 } else {
                     childProcess = child_process.spawn("rls");
                 }
+
                 childProcess.stderr.on('data', data => {});
+                childProcess.on('error', err => {
+                    if (err.code == "ENOENT") {
+                        console.error("Could not spawn rls process:", err.message);
+                        window.setStatusBarMessage("RLS Error: Could not spawn process");
+                    } else {
+                        throw err;
+                    }
+                })
+
                 return childProcess; // Uses stdin/stdout for communication
             }
 


### PR DESCRIPTION
- Catch ENOENT errors
- Print nicer error log than default
- Update the status bar with an error message

Without this, the user thinks that the RLS is still starting up.