### PR TITLE
Remove "hello world" contribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,6 @@
         "onLanguage:rust"
     ],
     "main": "./out/src/extension",
-    "contributes": {
-        "commands": [{
-            "command": "extension.sayHello",
-            "title": "Hello World"
-        }]
-    },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
         "compile": "tsc -watch -p ./",


### PR DESCRIPTION
This adds a "hello world" command to the command palette which fails because the command doesn't exist.