### PR TITLE
Update vscode-languageclient to 3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "dependencies": {
-        "vscode-languageclient": "^2.6.3",
-        "vscode-languageserver": "^2.6.2"
+        "vscode-languageclient": "^3.2.0"
     },
     "devDependencies": {
         "typescript": "^2.0.3",


### PR DESCRIPTION
Update vscode-languageclient to [3.2](https://github.com/Microsoft/vscode-languageserver-node#320-server-and-client) and remove dependency on vscode-languageserver, since it isn't used.
This also brings support to v3 spec of LSP (https://github.com/jonathandturner/rls_vscode/issues/56, e.g. `workspace/executeCommand` support, v3 `WorkspaceEdit`)
Additionally fixes `TypeError: Cannot read property 'dispose' of null`, which was a bug, and now properly attempts to restart the server in case it couldn't have been started properly in the first place.
Requires `npm install`.