### PR TITLE
Update README.md - Cannot read property 'dispose'

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,3 @@ if that doesn't work, run
 
 > echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
-### TypeError: Cannot read property 'dispose' of null
-
-change the `DEV_MODE` variable in `extension.ts` to `true` and try again to see the real error.


### PR DESCRIPTION
* `Cannot read property 'dispose' of null` was a bug that's been fixed in the current version of vscode-languageclient we're using
* `DEV_MODE` has been renamed to `HIDE_WINDOW_OUTPUT`